### PR TITLE
Add user profile testcases

### DIFF
--- a/api/schemas/user.py
+++ b/api/schemas/user.py
@@ -19,6 +19,7 @@ UserModel = get_user_model()
 class UserNode(DjangoObjectType):
     class Meta:
         model = UserModel
+        only_fields = ('username', 'email', 'profile')
         description = "User information"
 
 
@@ -37,13 +38,16 @@ class OAuthTokenAuth(graphene.Mutation):
     token = graphene.String()
 
     def mutate(self, info, oauth_type, client_id, code):
-        user = authenticate(
-            request=info.context,
-            oauth_type=oauth_type,
-            client_id=client_id,
-            code=code)
-
-        if user is None:
+        from requests.exceptions import HTTPError
+        try:
+            user = authenticate(
+                request=info.context,
+                oauth_type=oauth_type,
+                client_id=client_id,
+                code=code)
+        except HTTPError as e:
+            raise GraphQLError(e)
+        if user is None or user.is_anonymous:
             raise JSONWebTokenError(
                 'Please, enter valid credentials')
         payload = jwt_payload(user)
@@ -64,15 +68,15 @@ class UpdateProfile(graphene.Mutation):
     profile = graphene.Field(ProfileNode)
 
     class Arguments:
-        profile_data = ProfileInput(required=True)
+        profile_input = ProfileInput(required=True)
 
-    def mutate(self, info, profile_data=None):
+    def mutate(self, info, profile_input=None):
         user = info.context.user
         if not user.is_authenticated:
             raise GraphQLError('You must be logged to PyCon Korea')
         profile = create_profile_if_not_exists(user)
 
-        for k, v in profile_data.items():
+        for k, v in profile_input.items():
             setattr(profile, k, v)
 
         profile.full_clean()
@@ -90,9 +94,9 @@ class Mutations(graphene.ObjectType):
 
 
 class Query(graphene.ObjectType):
-    profile = graphene.Field(UserNode)
+    me = graphene.Field(UserNode)
 
-    def resolve_profile(self, info):
+    def resolve_me(self, info):
         user = info.context.user
         if not user.is_authenticated:
             raise GraphQLError('You must be logged to PyCon Korea')

--- a/api/tests/scheme/test_user.py
+++ b/api/tests/scheme/test_user.py
@@ -1,0 +1,161 @@
+from unittest import mock
+from graphql import GraphQLError
+from json import loads, dumps
+from django.utils.timezone import get_current_timezone
+from django.contrib.auth import get_user_model
+from api.tests.base import BaseTestCase
+from api.tests.data import initialize
+from api.schema import schema
+from api.models.program import Presentation
+from api.models.profile import Profile
+
+from api.tests.common import \
+    generate_mock_response, \
+    generate_request_authenticated
+from api.tests.oauth_app_response import \
+    GITHUB_USER_RESPONSE,\
+    GITHUB_EMAILS_RESPONSE, \
+    GITHUB_ACCESS_TOKEN_RESPONSE
+
+
+TIMEZONE = get_current_timezone()
+UserModel = get_user_model()
+
+
+class UserTestCase(BaseTestCase):
+    def setUp(self):
+        initialize()
+
+    @mock.patch('api.oauth_tokenbackend.requests.get')
+    @mock.patch('api.oauth_tokenbackend.requests.post')
+    def test_oauth_token_auth(self, mock_post, mock_get):
+        # Given
+        mock_access_token_resp = generate_mock_response(
+            status=200, content=GITHUB_ACCESS_TOKEN_RESPONSE)
+        mock_resp = generate_mock_response(
+            status=200, json=GITHUB_USER_RESPONSE)
+        mock_post.side_effect = [mock_access_token_resp]
+        mock_get.side_effect = [mock_resp]
+
+        # Given
+        mutation = '''
+        mutation OAuthTokenAuth($oauthType: String!, $clientId: String!, $code: String!) {
+            oAuthTokenAuth(oauthType: $oauthType, clientId: $clientId, code: $code) {
+                token
+            }
+        }
+        '''
+        variables = {
+            'oauthType': 'github',
+            'clientId': 'prod_github_client_id',
+            'code': 'CODE'
+        }
+
+        # When
+        result = schema.execute(mutation, variables=variables)
+
+        # Then
+        actual = loads(dumps(result.data))
+        self.assertIsNotNone(actual['oAuthTokenAuth']['token'])
+
+    def test_update_profile(self):
+        # Given
+        mutation = '''
+        mutation UpdateProfile($profileInput: ProfileInput!) {
+            updateProfile(profileInput: $profileInput) {
+                profile {
+                    user {
+                        username
+                        email
+                    }
+                    name
+                    bio
+                    phone
+                    organization
+                    nationality
+                }
+            }
+        }
+        '''
+        variables = {
+            'profileInput': {
+                'name': '코니',
+                'bio': '파이콘 한국을 참석하고 있지요',
+                'phone': '010-1111-1111',
+                'organization': '파이콘!',
+                'nationality': '미국',
+            }
+        }
+
+        expected = {
+            'updateProfile': {
+                'profile': {
+                    'user': {
+                        'username': 'develop_github_123',
+                        'email': 'me@pycon.kr'
+                    },
+                    **variables['profileInput']
+                }
+            }
+        }
+
+        user = UserModel(username='develop_github_123', email='me@pycon.kr')
+        user.save()
+        request = generate_request_authenticated(user)
+        result = schema.execute(
+            mutation, variables=variables, context_value=request)
+
+        # Then
+        actual = loads(dumps(result.data))
+        self.assertIsNotNone(actual)
+        self.assertDictEqual(actual, expected)
+
+    def test_me(self):
+        query = '''
+        query {
+            me {
+                username
+                email
+                profile {
+                    name
+                    bio
+                    phone
+                    organization
+                    nationality
+                }
+            }
+        }
+        '''
+
+        # Given
+        user = UserModel(username='develop_github_123', email='me@pycon.kr')
+        user.save()
+        user.profile.name = 'pycon_angel'
+        user.profile.bio = '파이콘 천사입니다.'
+        user.profile.phone = '222-2222-2222'
+        user.profile.organization = '좋은회사'
+        user.profile.nationality = '우리나라'
+        user.save()
+
+        request = generate_request_authenticated(user)
+
+        # When
+        result = schema.execute(query, context_value=request)
+        expected = {
+            'me': {
+                'username': 'develop_github_123',
+                'email': 'me@pycon.kr',
+                'profile': {
+                    'name': 'pycon_angel',
+                    'bio': '파이콘 천사입니다.',
+                    'phone': '222-2222-2222',
+                    'organization': '좋은회사',
+                    'nationality': '우리나라'
+                }
+            }
+        }
+
+        # Then
+        actual = loads(dumps(result.data))
+        self.assertIsNotNone(actual)
+        self.assertDictEqual(actual, expected)

--- a/api/tests/scheme/test_user.py
+++ b/api/tests/scheme/test_user.py
@@ -1,20 +1,17 @@
 from unittest import mock
-from graphql import GraphQLError
 from json import loads, dumps
 from django.utils.timezone import get_current_timezone
 from django.contrib.auth import get_user_model
 from api.tests.base import BaseTestCase
 from api.tests.data import initialize
 from api.schema import schema
-from api.models.program import Presentation
-from api.models.profile import Profile
 
 from api.tests.common import \
     generate_mock_response, \
     generate_request_authenticated
+
 from api.tests.oauth_app_response import \
     GITHUB_USER_RESPONSE,\
-    GITHUB_EMAILS_RESPONSE, \
     GITHUB_ACCESS_TOKEN_RESPONSE
 
 


### PR DESCRIPTION
## Your checklist for this pull request

> ⚠️ [파이콘 한국 Contributing Guide](./CONTRIBUTING.md)를 꼭 준수해주세요.

- [x] PR의 **compare branch를 master나 develop로 생성하지 않아야** 합니다. :smile:
- [x] PR의 **base branch는 develop으로 지정**해야 합니다.
- [x] Commit Message가 적절한지 확인해주세요
- [x] Lint나 Unit Test가 통과했는지 확인해주세요
- [x] 가급적이면 테스트 케이스를 작성해주세요
  - 테스트 커버리지는 **90% 이상**을 유지해야 합니다.

## Description

사용자 정보를 가져오는 API들의 테스트 케이스를 작성했습니다.

- 테스트 케이스를 바탕으로 client에서 사용 방법을 이해하길 기대합니다 😄 

### 테스트 API 상세

oauth code를 받아서 token을 발급해주는 mutation입니다.

```gql
mutation OAuthTokenAuth($oauthType: String!, $clientId: String!, $code: String!) {
    oAuthTokenAuth(oauthType: $oauthType, clientId: $clientId, code: $code) {
        token
    }
}
```

User profile을 받아오는 query

```gql
query {
    me {
        username
        email
        profile {
            name
            bio
            phone
            organization
            nationality
        }
    }
}
```

프로필을 수정하는 mutation

```gql
mutation UpdateProfile($profileInput: ProfileInput!) {
    updateProfile(profileInput: $profileInput) {
        profile {
            user {
                username
                email
            }
            name
            bio
            phone
            organization
            nationality
        }
    }
}
```


Thank you ❤️
